### PR TITLE
docs: spinner tips — Tip line under the working spinner

### DIFF
--- a/docs-site/docs/configuration/preference.mdx
+++ b/docs-site/docs/configuration/preference.mdx
@@ -20,6 +20,7 @@ Ante stores user preferences in `~/.ante/settings.json`:
   "has_completed_onboarding": true,
   "ambient_prompt_suggestion": true,
   "ambient_thinking_phrase": true,
+  "tips": true,
   "channel": "stable",
   "resize_reflow": "conservative",
   "status_line": ["model-name", "current-dir"],
@@ -55,6 +56,7 @@ Ante stores user preferences in `~/.ante/settings.json`:
 | `has_completed_onboarding` | Whether the onboarding flow has been completed |
 | `ambient_prompt_suggestion` | Whether the TUI shows a [next-prompt suggestion](/usage/tui#next-prompt-suggestion) as ghost text after a turn. On unless set to `false` |
 | `ambient_thinking_phrase` | Whether the TUI predicts a [task-specific spinner phrase](/usage/tui#spinner-thinking-phrase) while you type. On unless set to `false` |
+| `tips` | Whether the TUI shows a [tip line](/usage/tui#spinner-tips) under the spinner while the agent works. On unless set to `false` |
 | `channel` | Release channel `ante update` tracks (`stable` or `nightly`). Defaults to `stable`; legacy `latest` values are treated as `stable`. See [Update & Channels](/start/update). |
 | `resize_reflow` | Scrollback strategy on terminal resize: `conservative` (default) or `purge` (see below) |
 | `status_line` | Items to display in the TUI status line footer (see below) |

--- a/docs-site/docs/reference/storage-reference.mdx
+++ b/docs-site/docs/reference/storage-reference.mdx
@@ -17,6 +17,7 @@ Ante persists configuration and state on the local filesystem. This page is a re
 | `~/.ante/sessions/<session-id>/` | Persisted sessions (for `/resume` and `--resume`) |
 | `~/.ante/projects/<project-id>/memory/` | Per-project auto-memory |
 | `~/.ante/cache/<project-id>/` | Per-project temporary files |
+| `~/.ante/tip_history.json` | Show history for [spinner tips](/usage/tui#spinner-tips) (delete to reset the rotation) |
 | `AGENTS.md` | Project instructions injected alongside global instructions |
 | `.ante/` | Project-local configuration (skills, sub-agents) |
 | `.agents/`, `.claude/` | Additional project-local skill/sub-agent directories |

--- a/docs-site/docs/usage/tui.mdx
+++ b/docs-site/docs/usage/tui.mdx
@@ -183,6 +183,19 @@ The prediction is generated off the critical path on the cheapest available mode
 
 While you type a longer prompt, Ante predicts a short, task-specific phrase and uses it as the spinner label for that turn instead of the generic rotating messages. Like the next-prompt suggestion, it runs best-effort on the cheapest model off the critical path, and alarming or destructive words are filtered out of the phrase. On by default; disable with `"ambient_thinking_phrase": false` in `~/.ante/settings.json`.
 
+## Spinner tips
+
+While the agent works, Ante shows a short tip under the spinner pointing at a feature you might not have discovered yet:
+
+```
+◆ Thinking
+  └─ Tip: Press ctrl+r to search your prompt history.
+```
+
+Tips come from a small curated list (features, keyboard shortcuts, workflow habits) — no model call is involved. Selection is deterministic: the least recently shown eligible tip wins, each tip has a cooldown measured in app restarts so it doesn't repeat session after session, and a tip shown once stays quiet for the rest of that session. The tip appears when the turn starts, stays until the turn ends, and never enters the transcript.
+
+On by default; disable with `"tips": false` in `~/.ante/settings.json`. Show history lives in `~/.ante/tip_history.json` — delete it to reset the rotation.
+
 ## CLI flags for TUI mode
 
 ```bash


### PR DESCRIPTION
## Why

Ante's TUI now shows a curated "Tip:" line under the working spinner while the agent works, surfacing features, shortcuts, and workflow habits at the moment the user is idle and reading. New user-facing behavior needs documenting.

## What

- New "Spinner tips" section in the TUI page covering behavior (curated static list, deterministic least-recently-shown selection, per-tip cooldowns counted in app restarts, turn-scoped display, never in the transcript) and the `"tips": false` opt-out.
- `tips` field documented in the preferences example and field table.
- `tip_history.json` added to the storage reference locations.

## Test plan

- `npm run build` passes (includes Docusaurus link/anchor checks); the cross-page anchor `/usage/tui#spinner-tips` resolves.