### PR TITLE
docs: render changelog category headers as small labels

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -234,6 +234,18 @@ code {
   font-weight: 500;
 }
 
+/* Category headers (Added / Changed / Fixed) render as small labels
+   instead of full-size h3s */
+.docs-doc-id-changelog article h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
 .changelog-badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
The Added / Changed / Fixed headings on the rendered changelog page were full-size h3s, competing visually with the version headers. Restyle them as compact uppercase labels (0.8rem, muted), scoped to the changelog doc id so headings elsewhere are unaffected.