### PR TITLE
docs: clean up provider id reference to improve clarity

### DIFF
--- a/docs-site/docs/reference/catalog-reference.mdx
+++ b/docs-site/docs/reference/catalog-reference.mdx
@@ -9,7 +9,7 @@ This page is the exhaustive reference. For how to pick a provider day to day and
 
 ## Built-in providers
 
-| Provider | ID | Wire style | Authentication |
+| Provider | key | Wire style | Authentication |
 |---|---|---|---|
 | Anthropic | `anthropic` | `AnthropicMessage` | `ANTHROPIC_API_KEY` |
 | Anthropic Subscription | `anthropic-subscription` | `AnthropicMessage` | OAuth |
@@ -29,7 +29,7 @@ This page is the exhaustive reference. For how to pick a provider day to day and
 | Antix (API key) | `antix-api-key` | `AnthropicMessage` | `ANTIX_API_KEY` |
 | Local | `local` | `OpenAiCompatible` | none |
 
-The `ID` column is what you pass to `--provider`. Providers authenticating via OAuth (`anthropic-subscription`, `openai-subscription`, `antix`) sign in interactively through the TUI; the rest read an API key from the listed environment variable.
+The `key` column is what you pass to `--provider`. Providers authenticating via OAuth (`anthropic-subscription`, `openai-subscription`, `antix`) sign in interactively through the TUI; the rest read an API key from the listed environment variable.
 
 ## Models by provider
 
@@ -267,7 +267,7 @@ ante --provider local
 }
 ```
 
-A `providers` entry whose key matches a built-in (e.g. `openai`) patches that preset field by field; a new key adds a provider. The map key **is** the provider id — the value you pass to `--provider`. An `id` (or legacy `name`) field inside an entry is ignored.
+A `providers` entry whose key matches a built-in (e.g. `openai`) patches that preset field by field; a new key adds a provider. The map key is the value you pass to `--provider`. An `id` (or legacy `name`) field inside an entry is ignored.
 
 :::note
 `~/.ante` can be relocated with the `ANTE_HOME` environment variable; the catalog is always `$ANTE_HOME/catalog.json`.
@@ -275,11 +275,9 @@ A `providers` entry whose key matches a built-in (e.g. `openai`) patches that pr
 
 ### Provider fields
 
-The provider id comes from the map key, not from a field — there is no `id` field.
-
 | Field | Required | Description |
 |---|---|---|
-| `display_name` | New providers: optional | Friendly name shown in the TUI. New providers default to the provider id (the map key) when omitted. |
+| `display_name` | New providers: optional | Friendly name shown in the TUI. New providers default to the provider map key when omitted. |
 | `base_url` | New providers: ✅ | API base URL. |
 | `wire_style` | New providers: ✅ | API dialect Ante speaks — `AnthropicMessage`, `OpenAiCompatible`, `OpenAiResponse`, or `Gemini`. |
 | `auth` | — | How to authenticate (see [Authentication](#authentication)). Omit for a provider that needs no key. |

--- a/docs-site/docs/reference/storage-reference.mdx
+++ b/docs-site/docs/reference/storage-reference.mdx
@@ -61,7 +61,7 @@ See [Preferences](/configuration/preference) for the full field reference and th
 
 ## `catalog.json`
 
-Adds or overrides providers and models on top of the built-in catalog. Both top-level keys are optional and keyed by id — the `providers` map key is the provider id you pass to `--provider`. An entry whose key matches a built-in (e.g. `openai`) replaces it, a new key adds a provider, and a `models` entry patches that model's fields wherever it is defined.
+Adds or overrides providers and models on top of the built-in catalog. Both top-level keys are optional. The `my-provider` key is what you pass to `--provider`. An entry whose key matches a built-in (e.g. `openai`) replaces it, a new key adds a provider, and a `models` entry patches that model's fields wherever it is defined.
 
 ```json
 {

--- a/docs-site/docs/usage/providers.mdx
+++ b/docs-site/docs/usage/providers.mdx
@@ -15,7 +15,7 @@ You can set your provider three ways, in order of precedence:
 2. **Settings file** — set `provider` and `model` in `~/.ante/settings.json`
 3. **Auto-detect** — if you specify neither, Ante uses the first provider you have credentials for (and `local` if none).
 
-Every provider id you can pass to `--provider` is listed in the [Catalog Reference](/reference/catalog-reference#built-in-providers).
+Every provider key you can pass to `--provider` is listed in the [Catalog Reference](/reference/catalog-reference#built-in-providers).
 
 Mid-session, type `/providers` in the TUI: pick a connected provider, then confirm a model (and effort) from its scoped picker. Ante remembers the last model you used on each provider. See [Models, Providers & Effort](/usage/models-and-thinking#switching-providers).
 


### PR DESCRIPTION
Changed all `id` reference for provider field to `key` but one line describing backward compatibility.
All `id` in catalog reference now only refer to model field `id` key.