### PR TITLE
fix(ci): harden Harbor shell execution

### DIFF
--- a/.github/workflows/ante-harbor.yml
+++ b/.github/workflows/ante-harbor.yml
@@ -52,29 +52,44 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Display all workflow inputs
+        env:
+          INSTALL_ARGS: ${{ github.event.inputs.install_args }}
+          HARBOR_ARGS: ${{ github.event.inputs.harbor_args }}
+          MODEL_NAME: ${{ github.event.inputs.model_name }}
+          PROVIDER: ${{ github.event.inputs.provider }}
+          EFFORT: ${{ github.event.inputs.effort }}
+          MODEL_BASE_URL: ${{ github.event.inputs.model_base_url }}
+          MODEL_TEMPERATURE: ${{ github.event.inputs.model_temperature }}
+          MODEL_MAX_TOKENS: ${{ github.event.inputs.model_max_tokens }}
+          RUNS_ON: ${{ github.event.inputs.runs_on }}
+          RUN_COUNT: ${{ github.event.inputs.run_count }}
         run: |
           echo "=========================================="
           echo "         Workflow Input Parameters        "
           echo "=========================================="
-          echo "install_args:      ${{ github.event.inputs.install_args }}"
-          echo "harbor_args:       ${{ github.event.inputs.harbor_args }}"
-          echo "model_name:        ${{ github.event.inputs.model_name }}"
-          echo "provider:          ${{ github.event.inputs.provider }}"
-          echo "effort:            ${{ github.event.inputs.effort }}"
-          echo "model_base_url:    ${{ github.event.inputs.model_base_url }}"
-          echo "model_temperature: ${{ github.event.inputs.model_temperature }}"
-          echo "model_max_tokens:  ${{ github.event.inputs.model_max_tokens }}"
-          echo "runs_on:           ${{ github.event.inputs.runs_on }}"
-          echo "run_count:         ${{ github.event.inputs.run_count }}"
+          printf 'install_args:      %s\n' "$INSTALL_ARGS"
+          printf 'harbor_args:       %s\n' "$HARBOR_ARGS"
+          printf 'model_name:        %s\n' "$MODEL_NAME"
+          printf 'provider:          %s\n' "$PROVIDER"
+          printf 'effort:            %s\n' "$EFFORT"
+          printf 'model_base_url:    %s\n' "$MODEL_BASE_URL"
+          printf 'model_temperature: %s\n' "$MODEL_TEMPERATURE"
+          printf 'model_max_tokens:  %s\n' "$MODEL_MAX_TOKENS"
+          printf 'runs_on:           %s\n' "$RUNS_ON"
+          printf 'run_count:         %s\n' "$RUN_COUNT"
           echo "=========================================="
 
       - name: Generate run matrix
         id: set-matrix
+        env:
+          RUN_COUNT: ${{ github.event.inputs.run_count || '1' }}
         run: |
-          COUNT=${{ github.event.inputs.run_count || '1' }}
-          # Generate array [1, 2, 3, ..., COUNT]
-          MATRIX=$(seq 1 $COUNT | jq -R . | jq -s -c .)
-          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          case "$RUN_COUNT" in
+            [1-9]|[1-9][0-9]|100) ;;
+            *) echo "run_count must be an integer from 1 to 100" >&2; exit 1 ;;
+          esac
+          MATRIX=$(seq 1 "$RUN_COUNT" | jq -R . | jq -s -c .)
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "Generated matrix: $MATRIX"
 
   # Second job: Run Harbor tests (each matrix item is a separate job)
@@ -133,6 +148,8 @@ jobs:
           MODEL_BASE_URL: ${{ github.event.inputs.model_base_url }}
           MODEL_TEMPERATURE: ${{ github.event.inputs.model_temperature }}
           MODEL_MAX_TOKENS: ${{ github.event.inputs.model_max_tokens }}
+          RUN_COUNT: ${{ github.event.inputs.run_count }}
+          RUN_INDEX: ${{ matrix.run_index }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -140,7 +157,7 @@ jobs:
         run: |
           cd $HOME/harbor
 
-          echo "=== Run ${{ matrix.run_index }} of ${{ github.event.inputs.run_count }} ==="
+          echo "=== Run $RUN_INDEX of $RUN_COUNT ==="
           echo "Running harbor with args: $HARBOR_ARGS and model: $MODEL_NAME"
 
           # Only the selected provider's credential is forwarded into the sandbox.
@@ -170,7 +187,8 @@ jobs:
               CMD+=(--ae "$key=\${$key}")
             fi
           done
-          CMD+=($HARBOR_ARGS)
+          read -r -a HARBOR_ARGV <<< "$HARBOR_ARGS"
+          CMD+=("${HARBOR_ARGV[@]}")
 
           # The adapter is imported from the checkout; harbor resolves it via PYTHONPATH.
           export PYTHONPATH="$GITHUB_WORKSPACE/ante-harbor${PYTHONPATH:+:$PYTHONPATH}"

--- a/ante-harbor/README.md
+++ b/ante-harbor/README.md
@@ -92,7 +92,7 @@ install.sh (`https://download.ante.run/install.sh`) using `install_args`.
 - **Description**: Number of times to run Harbor tests (each run is a separate job)
 - **Default**: `1`
 - **Required**: No
-- **Usage**: Number of independent test runs to execute. Each run is a separate job. The workflow is configured with a 120-hour timeout (`timeout-minutes: 7200`), but note that GitHub-hosted runners have a hard 6-hour limit regardless of the configured timeout. Self-hosted runners can utilize the full 120-hour timeout. Runs execute sequentially (`max-parallel: 1`). Useful for long-running tests that exceed a single job's time limit on GitHub-hosted runners.
+- **Usage**: Number of independent test runs to execute (an integer from 1 to 100). Each run is a separate job. The workflow is configured with a 120-hour timeout (`timeout-minutes: 7200`), but note that GitHub-hosted runners have a hard 6-hour limit regardless of the configured timeout. Self-hosted runners can utilize the full 120-hour timeout. Runs execute sequentially (`max-parallel: 1`). Useful for long-running tests that exceed a single job's time limit on GitHub-hosted runners.
 
 ## Execution Details
 

--- a/ante-harbor/ante_agent.py
+++ b/ante-harbor/ante_agent.py
@@ -147,28 +147,49 @@ def with_install_prerequisites(command: str) -> str:
     return "\n".join([install_prerequisites_command(), command])
 
 
-def setup_log_command(command: str, *, append: bool = True) -> str:
-    """Mirror setup output to Harbor Hub's conventional setup log path."""
-    escaped_setup_dir = shlex.quote(str(_SETUP_LOG.parent))
-    escaped_setup_path = shlex.quote(str(_SETUP_LOG))
-    tee_args = f"-a {escaped_setup_path}" if append else escaped_setup_path
+def _tee_command(command: str, log_path: Path, *, append: bool) -> str:
+    escaped_log_dir = shlex.quote(str(log_path.parent))
+    escaped_log_path = shlex.quote(str(log_path))
+    tee_args = f"-a {escaped_log_path}" if append else escaped_log_path
     return "\n".join(
         [
-            f"mkdir -p {escaped_setup_dir}",
+            f"mkdir -p {escaped_log_dir} || exit",
+            "status_file=$(mktemp) || exit",
+            "trap 'rm -f \"$status_file\"' EXIT",
             "{",
-            command,
+            f"  sh -c {shlex.quote(command)}",
+            "  command_status=$?",
+            "  printf '%s\\n' \"$command_status\" > \"$status_file\" || exit",
             f"}} 2>&1 | tee {tee_args}",
+            "tee_status=$?",
+            "command_status=$(cat \"$status_file\") || exit",
+            "case \"$command_status\" in ''|*[!0-9]*) exit 1 ;; esac",
+            "if [ \"$command_status\" -ne 0 ]; then exit \"$command_status\"; fi",
+            "exit \"$tee_status\"",
         ]
     )
+
+
+def setup_log_command(command: str, *, append: bool = True) -> str:
+    """Mirror setup output to Harbor Hub's conventional setup log path."""
+    logged_command = "\n".join(["set -e", command])
+    return _tee_command(logged_command, _SETUP_LOG, append=append)
 
 
 def install_command_from_args(install_args: str) -> str:
     """Build a robust in-sandbox install.sh command for published Ante builds."""
     quoted_args = " ".join(shlex.quote(arg) for arg in shlex.split(install_args or ""))
-    install_line = (
-        "curl -fsSL https://download.ante.run/install.sh | "
-        f"ANTE_INSTALL_DIR=/usr/local/bin NO_MODIFY_PATH=true bash -s -- {quoted_args}"
-    ).rstrip()
+    install_line = "\n".join(
+        [
+            "installer=$(mktemp)",
+            "trap 'rm -f \"$installer\"' EXIT",
+            "curl -fsSL https://download.ante.run/install.sh -o \"$installer\"",
+            (
+                "ANTE_INSTALL_DIR=/usr/local/bin NO_MODIFY_PATH=true "
+                f'bash "$installer" {quoted_args}'
+            ).rstrip(),
+        ]
+    )
     return with_install_prerequisites(install_line)
 
 
@@ -204,14 +225,14 @@ def ante_command(
         args += ["--effort", effort]
     args += split_extra_ante_args(ante_args)
     command = " ".join(shlex.quote(arg) for arg in args)
-    escaped_log_dir = shlex.quote(str(_AGENT_LOG.parent))
-    escaped_log_path = shlex.quote(str(_AGENT_LOG))
     escaped_instruction_path = shlex.quote(str(_INSTRUCTION_PATH))
-    return (
-        f"trap 'rm -f {escaped_instruction_path}' EXIT && "
-        f"mkdir -p {escaped_log_dir} && "
-        f"{command} < {escaped_instruction_path} 2>&1 | tee {escaped_log_path}"
+    logged_command = "\n".join(
+        [
+            f"trap 'rm -f {escaped_instruction_path}' EXIT",
+            f"{command} < {escaped_instruction_path}",
+        ]
     )
+    return _tee_command(logged_command, _AGENT_LOG, append=False)
 
 
 async def upload_instruction(environment: BaseEnvironment, instruction: str) -> None:

--- a/ante-harbor/test_ante_agent.py
+++ b/ante-harbor/test_ante_agent.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class _Model:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.__dict__.update(kwargs)
+
+    def to_json_dict(self):
+        return self.__dict__
+
+
+class _BaseInstalledAgent:
+    pass
+
+
+def _install_harbor_stubs() -> None:
+    modules = {
+        "harbor": types.ModuleType("harbor"),
+        "harbor.agents": types.ModuleType("harbor.agents"),
+        "harbor.agents.installed": types.ModuleType("harbor.agents.installed"),
+        "harbor.agents.installed.base": types.ModuleType("harbor.agents.installed.base"),
+        "harbor.environments": types.ModuleType("harbor.environments"),
+        "harbor.environments.base": types.ModuleType("harbor.environments.base"),
+        "harbor.models": types.ModuleType("harbor.models"),
+        "harbor.models.agent": types.ModuleType("harbor.models.agent"),
+        "harbor.models.agent.context": types.ModuleType("harbor.models.agent.context"),
+        "harbor.models.trajectories": types.ModuleType("harbor.models.trajectories"),
+        "harbor.utils": types.ModuleType("harbor.utils"),
+        "harbor.utils.trajectory_utils": types.ModuleType("harbor.utils.trajectory_utils"),
+    }
+    base = modules["harbor.agents.installed.base"]
+    for name in (
+        "AgentAuthenticationError",
+        "AgentSafetyRefusalError",
+        "ApiConnectionClosedError",
+        "ApiInternalServerError",
+        "ApiOverloadedError",
+        "ApiRateLimitError",
+        "ApiUsageLimitError",
+        "ContextWindowExceededError",
+        "NetworkConnectionError",
+        "NonZeroAgentExitCodeError",
+        "UnknownApiError",
+    ):
+        setattr(base, name, type(name, (Exception,), {}))
+    base.BaseInstalledAgent = _BaseInstalledAgent
+    base.CliFlag = _Model
+    base.EnvVar = _Model
+    base.with_prompt_template = lambda function: function
+    modules["harbor.environments.base"].BaseEnvironment = _Model
+    modules["harbor.models.agent.context"].AgentContext = _Model
+    trajectories = modules["harbor.models.trajectories"]
+    for name in (
+        "Agent",
+        "FinalMetrics",
+        "Metrics",
+        "Observation",
+        "ObservationResult",
+        "Step",
+        "ToolCall",
+        "Trajectory",
+    ):
+        setattr(trajectories, name, _Model)
+    modules["harbor.utils.trajectory_utils"].format_trajectory_json = str
+    sys.modules.update(modules)
+
+
+_install_harbor_stubs()
+sys.path.insert(0, str(Path(__file__).parent))
+ante_agent = importlib.import_module("ante_agent")
+
+
+class ShellCommandTests(unittest.TestCase):
+    def run_shell(self, command: str, *, path: Path | None = None) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        if path is not None:
+            env["PATH"] = f"{path}{os.pathsep}{env['PATH']}"
+        return subprocess.run(["sh", "-c", command], text=True, capture_output=True, env=env)
+
+    def test_tee_command_preserves_command_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "command.log"
+            command = ante_agent._tee_command("printf 'failed output\\n'; exit 23", log, append=False)
+            result = self.run_shell(command)
+
+            self.assertEqual(result.returncode, 23)
+            self.assertEqual(log.read_text(), "failed output\n")
+
+    def test_tee_command_preserves_tee_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            tee = root / "tee"
+            tee.write_text("#!/bin/sh\ncat >/dev/null\nexit 31\n")
+            tee.chmod(0o755)
+            log = root / "command.log"
+            command = ante_agent._tee_command("exit 0", log, append=False)
+            result = self.run_shell(command, path=root)
+
+            self.assertEqual(result.returncode, 31)
+
+    def test_ante_command_preserves_agent_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            binary = root / "ante"
+            binary.write_text("#!/bin/sh\ncat >/dev/null\nprintf 'agent output\\n'\nexit 19\n")
+            binary.chmod(0o755)
+            instruction = root / "instruction.md"
+            instruction.write_text("test instruction")
+            log = root / "logs" / "ante.txt"
+
+            with (
+                patch.object(ante_agent, "_AGENT_LOG", log),
+                patch.object(ante_agent, "_INSTRUCTION_PATH", instruction),
+            ):
+                command = ante_agent.ante_command("test-model", None, None, "")
+            result = self.run_shell(command, path=root)
+
+            self.assertEqual(result.returncode, 19)
+            self.assertEqual(log.read_text(), "agent output\n")
+            self.assertFalse(instruction.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- preserve Ante, setup, and `tee` exit statuses while mirroring Harbor logs
- download `install.sh` before execution so curl failures cannot be hidden by a pipeline
- pass `workflow_dispatch` values through environment variables instead of interpolating them into shell scripts
- validate `run_count` as an integer from 1 to 100
- add regression tests for agent and `tee` failure propagation

## Why

The adapter piped setup and agent commands directly into `tee`. Without `pipefail`, a failing command could be reported as successful, bypassing Harbor error classification. The workflow also interpolated dispatch inputs directly into `run:` blocks, allowing shell metacharacters in manually supplied values to alter the script executed on the runner.

## Verification

- `python3 -m unittest discover -s ante-harbor -p 'test_*.py' -v`\n- `python3 -m py_compile ante-harbor/ante_agent.py ante-harbor/ante_events.py ante-harbor/test_ante_agent.py`\n- parsed `.github/workflows/ante-harbor.yml` with PyYAML\n- `npm --prefix docs-site run build`\n- `git diff --check`