### PR TITLE
docs: point upstream links at the repositories' current names

### DIFF
--- a/docs-site/docs/benchmarks/eval.mdx
+++ b/docs-site/docs/benchmarks/eval.mdx
@@ -11,7 +11,7 @@ description: "Public, reproducible benchmarks of the exact builds we ship — li
 Our benchmarks are designed to be checked:
 
 - **We benchmark what we ship.** Every eval runs against a pinned, publicly downloadable Ante release, the same binary `ante update` installs (e.g. `0.preview.43`). No eval-only branches, no benchmark-specific prompts.
-- **The runs are auditable.** Every result links its raw [Harbor](https://github.com/laude-institute/harbor) run, so anyone can inspect the trials behind the number.
+- **The runs are auditable.** Every result links its raw [Harbor](https://github.com/harbor-framework/harbor) run, so anyone can inspect the trials behind the number.
 - **The constraints are official.** All trials use the same parameters as the official Terminal-Bench leaderboard: 89 tasks, 5 trials per task, strict timeouts and hardware limits.
 - **The results are live.** We publish continuously at [antigma.ai/eval](https://antigma.ai/eval).
 
@@ -65,7 +65,7 @@ A good harness moves the frontier down-market: it makes open-weight models do wo
   </figure>
 </div>
 
-We use [Terminal Bench](https://github.com/laude-institute/terminal-bench) and [Harbor](https://github.com/laude-institute/harbor) as our primary external benchmark. The team behind Harbor and Terminal Bench are genuine researchers — rigorous, principled, and motivated by getting it right rather than hype.
+We use [Terminal Bench](https://github.com/harbor-framework/terminal-bench-1) and [Harbor](https://github.com/harbor-framework/harbor) as our primary external benchmark. The team behind Harbor and Terminal Bench are genuine researchers — rigorous, principled, and motivated by getting it right rather than hype.
 
 Why Terminal Bench:
 - **Rigorous.** Unambiguous task specs, deterministic grading where possible, and isolated execution environments.

--- a/docs-site/docs/local/offline.mdx
+++ b/docs-site/docs/local/offline.mdx
@@ -3,7 +3,7 @@ title: Offline Mode
 description: "Run local GGUF models through Ante's natively managed llama.cpp engine"
 ---
 
-Ante runs local GGUF models through a natively managed [llama.cpp](https://github.com/ggerganov/llama.cpp) engine. No API key, no account: point Ante at a model file and the full agent loop runs on your hardware. Once a model is on disk, inference needs no network connection at all.
+Ante runs local GGUF models through a natively managed [llama.cpp](https://github.com/ggml-org/llama.cpp) engine. No API key, no account: point Ante at a model file and the full agent loop runs on your hardware. Once a model is on disk, inference needs no network connection at all.
 
 For a fully disconnected run, set `ANTE_TELEMETRY=off` as well. This disables application metrics and log export independently of local inference; see [Telemetry](/configuration/preference#telemetry).
 


### PR DESCRIPTION
Three GitHub links in the docs still use owner names the projects have moved away from. They resolve today only because GitHub redirects a renamed repository, and that redirect stops working as soon as anyone registers the old name.

| Doc | Was | Now |
| --- | --- | --- |
| `local/offline.mdx` | `ggerganov/llama.cpp` | `ggml-org/llama.cpp` |
| `benchmarks/eval.mdx` | `laude-institute/harbor` | `harbor-framework/harbor` |
| `benchmarks/eval.mdx` | `laude-institute/terminal-bench` | `harbor-framework/terminal-bench-1` |

Terminal Bench is the one worth a second look. The original repository was renamed to `harbor-framework/terminal-bench-1`, and `harbor-framework/terminal-bench` is now a **different** project that has taken the plain name. So that link is not just stale, it points at a name which today belongs to something else. Following the old URL happens to land correctly for now purely because of the redirect.

## Verification

Checked every external link in `docs-site/docs` (43 unique URLs). These three were the only ones redirecting to a different owner or name. After the change all three resolve with no redirect at all:

```
200 redirects=0  https://github.com/ggml-org/llama.cpp
200 redirects=0  https://github.com/harbor-framework/harbor
200 redirects=0  https://github.com/harbor-framework/terminal-bench-1
```

I also confirmed each destination is the intended project rather than a lookalike: `ggml-org/llama.cpp` is "LLM inference in C/C++", `harbor-framework/harbor` is "Framework for evaluating and improving agents", and `harbor-framework/terminal-bench-1` is "A benchmark for LLMs on complicated tasks in the terminal".

Link text and surrounding prose are untouched, and the Simplified Chinese localization does not carry these pages, so nothing under `i18n/` needs the same edit.
