### PR TITLE
ci: update renamed ante-sdk crate

### DIFF
--- a/.github/workflows/public-crates.yml
+++ b/.github/workflows/public-crates.yml
@@ -36,9 +36,9 @@ jobs:
           - crate: exec
             manifest: crates/exec/Cargo.toml
             workspace: crates/exec
-          - crate: agent-sdk
-            manifest: crates/agent-sdk/Cargo.toml
-            workspace: crates/agent-sdk
+          - crate: ante-sdk
+            manifest: crates/ante-sdk/Cargo.toml
+            workspace: crates/ante-sdk
           - crate: llm
             manifest: crates/llm/Cargo.toml
             workspace: crates/llm


### PR DESCRIPTION
## Summary

- update the Public Crates matrix after `agent-sdk` was renamed to `ante-sdk`
- point the manifest and Rust cache workspace at `crates/ante-sdk`

## Validation

- workflow YAML parses successfully
- action linting passes
- the corrected manifest path exists on current `main`