### PR TITLE
docs: supported_efforts field and /add-provider command

### DIFF
--- a/docs-site/docs/reference/catalog-reference.mdx
+++ b/docs-site/docs/reference/catalog-reference.mdx
@@ -301,7 +301,8 @@ A `providers` entry whose key matches a built-in (e.g. `openai`) patches that pr
           "description": "My fine-tuned model",
           "max_tokens": 32000,
           "context_limit": 200000,
-          "effort": "medium"
+          "effort": "medium",
+          "supported_efforts": ["low", "medium", "high"]
         }
       ]
     }
@@ -397,6 +398,7 @@ The same fields describe a model fully inside a provider's `preferred_models` (w
 | `stop_sequences` | List of strings that end generation. |
 | `context_limit` | Context window size, in tokens. |
 | `effort` | Default [effort level](/usage/models-and-thinking#effort) — `min`, `low`, `medium`, `high`, `xhigh`, or `max`. Omit for models with no reasoning knob (Ante then sends no effort parameter and hides the effort slider). |
+| `supported_efforts` | The effort levels this model accepts on this provider, ascending (same values as `effort`). Replaces the built-in ladder: the effort slider shows exactly these levels, and OpenAI-compatible providers send the selected level as the same-named `reasoning_effort` (`min` is sent as `minimal`). An empty list declares that the model takes no effort setting. Omit to keep the built-in ladder. |
 | `weight_class` | Size/cost tier — `Feather`, `Middle`, or `Heavy`. Drives automatic default and auxiliary model selection (see [Weight classes](#weight-classes)). |
 | `support_vision` | Whether the model accepts image input. When omitted, Ante infers it from the model id; an image read against a model with no vision support returns the image's metadata instead of its pixels. |
 

--- a/docs-site/docs/usage/models-and-thinking.mdx
+++ b/docs-site/docs/usage/models-and-thinking.mdx
@@ -36,6 +36,8 @@ min · low · medium · high · xhigh · max
 
 In `/models`, effort is a slider under the model list with one tick per level the selected model actually supports — a model with four native levels shows four ticks, one with all six shows six. Models with no reasoning knob show no slider.
 
+The ladder is built in per provider and model family. For custom providers you can declare it yourself with `supported_efforts` on the model's catalog entry (see the [Catalog Reference](/reference/catalog-reference#model-fields)) — or run `/add-provider`, which probes the endpoint and writes the declaration for you.
+
 :::note
 Anthropic's API requires `temperature: 1` whenever thinking is active. If you've set a different `temperature` for a Claude model in your [catalog](/reference/catalog-reference#model-fields) or via `MODEL_TEMPERATURE`, turns with thinking on fail with a message saying so — clear the override to fix it.
 :::

--- a/docs-site/docs/usage/providers.mdx
+++ b/docs-site/docs/usage/providers.mdx
@@ -50,7 +50,7 @@ When using third-party providers, make sure the model supports tool use (functio
 
 ## Custom catalog
 
-Create `~/.ante/catalog.json` to add a provider Ante doesn't ship, patch a built-in one, or tweak a model's defaults. It is merged on top of the built-in presets at startup, so you only specify what you want to add or change. The examples below are the common cases; see the [Catalog Reference](/reference/catalog-reference#catalogjson-schema) for the full schema, authentication forms, and resolution rules.
+Create `~/.ante/catalog.json` to add a provider Ante doesn't ship, patch a built-in one, or tweak a model's defaults. It is merged on top of the built-in presets at startup, so you only specify what you want to add or change. Prefer not to write it by hand? Run `/add-provider` in the TUI: Ante discovers the endpoint's models, can probe which effort levels each one accepts, and writes the entry for you (restart to load it). The examples below are the common cases; see the [Catalog Reference](/reference/catalog-reference#catalogjson-schema) for the full schema, authentication forms, and resolution rules.
 
 ### Add a hosted provider
 
@@ -82,6 +82,22 @@ Most hosted endpoints are OpenAI-compatible. Register one with `wire_style: "Ope
 export TOGETHER_API_KEY="..."
 ante --provider together --model moonshotai/Kimi-K2-Instruct
 ```
+
+### Declare the effort levels a model accepts
+
+The [effort slider](/usage/models-and-thinking#effort)'s ladder is built in per provider and model family, so a model on a custom endpoint may get a ladder that doesn't match what the endpoint really accepts. Declare the true set with `supported_efforts` — the slider then shows exactly those levels, and OpenAI-compatible providers send the selected level as the same-named `reasoning_effort`:
+
+```json
+"preferred_models": [
+  {
+    "id": "kimi-k3",
+    "effort": "high",
+    "supported_efforts": ["low", "medium", "high"]
+  }
+]
+```
+
+An empty list (`"supported_efforts": []`) declares that the model takes no effort setting at all. There is no API that reports supported levels, so when in doubt let `/add-provider` probe the endpoint for you.
 
 ### Add a local provider with no auth
 

--- a/docs-site/docs/usage/slash-commands.mdx
+++ b/docs-site/docs/usage/slash-commands.mdx
@@ -19,6 +19,7 @@ Type `/` in the [interactive TUI](/usage/tui) to run built-in commands for commo
 | `/connect` | Sign in with OAuth (API keys are detected automatically) |
 | `/models [model_id]` | With no argument, open the model and effort picker for the current provider; with a model id, switch to it directly — including ids the catalog does not list |
 | `/providers` | Select an available provider for the current session |
+| `/add-provider` | Set up a custom provider in `catalog.json` — discovers the endpoint's models and can probe which effort levels each accepts (see [Custom catalog](/usage/providers#custom-catalog)) |
 | `/offline-mode` | Run a local model with the built-in inference engine |
 | `/term [name [args...]]` | With no name, open the terminal-session picker; with a name, attach or detach that tmux session, launching a same-named command plus arguments when the session is new — see [Terminal sessions](/usage/tui#terminal-sessions) |
 | `/update [skip \| cancel]` | Schedule the pending update for installation on exit; `skip` dismisses that version and `cancel` unschedules an accepted update |


### PR DESCRIPTION
## Why

The effort slider's ladder is built in per provider and model family, so a model served by a custom endpoint could show levels that don't match what the endpoint accepts — with no way to correct it. Ante now supports declaring the accepted set per model (`supported_efforts` in `catalog.json`) and a `/add-provider` command that discovers a custom endpoint's models, probes accepted effort levels, and writes the catalog entry. Neither is discoverable without docs.

Closes the documentation side of #164.

## What

- Providers guide: `/add-provider` pointer in the Custom catalog intro, and a new "Declare the effort levels a model accepts" subsection with an example and the empty-list (no effort knob) semantics.
- Catalog reference: `supported_efforts` in the Model fields table and schema example.
- Models & thinking: note on where the slider's ladder comes from and how to override it.
- Slash commands: `/add-provider` row.

## Test plan

`npm run build` passes (both locales). Links checked against existing anchors (`#model-fields`, `#effort`, `#custom-catalog`).